### PR TITLE
chore: ml-api-docker-k8 to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.118
+- name: ml-api-docker-k8
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1
 - name: myexample
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
chore: Promote ml-api-docker-k8 to version 0.0.1